### PR TITLE
Fix: graph visualization with chapter names containing non-numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "magebook",
-  "version": "1.2.13",
+  "version": "1.2.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "magebook",
-      "version": "1.2.13",
+      "version": "1.2.16",
       "license": "MIT",
       "dependencies": {
         "@codemirror/view": "^6.6.0",

--- a/src/javascript/graph.ts
+++ b/src/javascript/graph.ts
@@ -25,17 +25,17 @@ const generateGraph = (book) => {
     node  [fontname="arial", fontsize=12, style="rounded,filled", shape=box];
     edge  [fontname="arial", fontsize=12];
   `
-  
+
   const groups = Object.fromEntries([...indexedBook.groups].map(group => [group, []]))
 
 
   for(let [key, {title, group, links, flags, text}] of indexedBook.chapters){
     s += `
-      ${key} [label="${sanitizeLabel(title ? `${key} - ${title}` : key)}", tooltip="${text.replaceAll(/[^0-9a-z \`\<\>\.\'\[\]\(\)]/gi, '')}"${nodeStyle(key, flags, indexedBook)}]`
+      "${key}" [label="${sanitizeLabel(title ? `${key} - ${title}` : key)}", tooltip="${text.replaceAll(/[^0-9a-z \`\<\>\.\'\[\]\(\)]/gi, '')}"${nodeStyle(key, flags, indexedBook)}]`
 
     for(const link of links){
       if(indexedBook.chapters.has(link)) s += `
-        ${key} -> ${sanitizeLink(link)}`
+        "${key}" -> "${sanitizeLink(link)}"`
 
     }
     if(group) groups[group].push(key)


### PR DESCRIPTION
Due to how viz.js works, if a node ID starts with a number, it can only contain numbers. If it contains letters, it must be escaped with doublequotes.

Take this example:

```
digraph{
    graph [fontname="arial", fontsize=10]; 
    node  [fontname="arial", fontsize=12, style="rounded,filled", shape=box];
    edge  [fontname="arial", fontsize=12];
  
      1
        1 -> 1a
        1 -> 1b
}
```

This is parsed as `1 -> 1` twice:
![image](https://user-images.githubusercontent.com/71387/234938282-96c1d1aa-25cb-42f3-b60f-3c6ab79672da.png)

While
```
digraph{
    graph [fontname="arial", fontsize=10]; 
    node  [fontname="arial", fontsize=12, style="rounded,filled", shape=box];
    edge  [fontname="arial", fontsize=12];
  
      1
        1 -> "1a"
        1 -> "1b"
}
```

is correctly parsed:
![image](https://user-images.githubusercontent.com/71387/234938447-c053356d-0b3c-42f9-8f60-b4c3b4061965.png)

You can see it in MageBook with this simple test story:

```
# Test
### 1
Start
[Choice 1](#1a)
[Choice 2](#1b)
### 1a
Body of chapter 1a
[Choice 1](#2b)
[Choice 2](#2a)
### 1b
Body of chapter 1b
[Choice 1](#3)
### 2a
Body of chapter 2a
[Choice 1](#1a)
[Choice 2](#4)
### 2b
Body of chapter 2b
[Choice 1](#4)
### 3
Body of chapter 3
[Choice 1](#4)
### 4
![][flag-final]
The end.
```

Which generates
![Test](https://user-images.githubusercontent.com/71387/234938904-e289b0a6-e2ae-4721-a9bc-082f1a843295.svg)

Instead of
![Test (1)](https://user-images.githubusercontent.com/71387/234938937-d434ad7b-7a59-4cb7-aa59-1a9f7f209068.svg)

Not sure whether this fixes issue #1 as well, as the author hasn't provided an example.